### PR TITLE
Fix access mode to read only for ReadFile

### DIFF
--- a/ModLoader/ModLoader.cs
+++ b/ModLoader/ModLoader.cs
@@ -17,7 +17,7 @@ namespace Loader
 		// Token: 0x06002342 RID: 9026 RVA: 0x000B10B4 File Offset: 0x000AF2B4
 		public static byte[] ReadFile(string path)
 		{
-			FileStream fileStream = File.Open(path, FileMode.Open);
+			FileStream fileStream = File.Open(path, FileMode.Open, FileAccess.Read);
 			byte[] result;
 			using (MemoryStream memoryStream = new MemoryStream())
 			{


### PR DESCRIPTION
This method is used by main EXILED library to load plugins. It does not need write access actually and may cause issues loading plugins in some setups.